### PR TITLE
Don’t check if the commands exist

### DIFF
--- a/etc/bash_completion.d/cargo
+++ b/etc/bash_completion.d/cargo
@@ -2,7 +2,6 @@
 # Bash completion for cargo
 #
 
-have cargo &&
 _cargo()
 {
     local cur prev helpopts comopts comstring
@@ -28,5 +27,5 @@ _cargo()
 
     COMPREPLY=( $( compgen -W "${comstring} ${helpopts} help" -- "$cur" ) )
     return 0
-} &&
+}
 complete -F _cargo cargo

--- a/etc/bash_completion.d/rustc
+++ b/etc/bash_completion.d/rustc
@@ -2,7 +2,6 @@
 # Bash completion for rustc
 #
 
-have rustc &&
 _rustc()
 {
     local cur prev helpopts codegenopts warnopts debugopts
@@ -90,5 +89,5 @@ _rustc()
 	_compopt_o_filenames
 	COMPREPLY=( $( compgen -d -- "$cur" ) $( compgen -f -X "!$xspec" -- "$cur" ) )
 
-} &&
+}
 complete -F _rustc rustc


### PR DESCRIPTION
This fixes #1. It’s not necessary to check if the commands exist before defining the completion functions.
